### PR TITLE
Fixed a bug failing to stat mmdb files when first-time sync

### DIFF
--- a/maxmind-geoip-updater.sh
+++ b/maxmind-geoip-updater.sh
@@ -49,7 +49,9 @@ if [ ! -e $DEST/$CITY_DB ] || [ ! -e $DEST/$CITY_MD5 ] || [ "$(diff $TMP/$CITY_M
 
   if [ "$(diff $TMP/CITY_MD5 $TMP/$CITY_MD5)" == "" ]; then
     tar -xf $TMP/$CITY --no-same-owner --strip 1 -C $TMP
-    mv $DEST/$CITY_DB $DEST/$CITY_DB.old
+    if [ -e $DEST/$CITY_DB ]; then
+        mv $DEST/$CITY_DB $DEST/$CITY_DB.old
+    fi
     mv $TMP/$CITY_DB $DEST/$CITY_DB
     mv $TMP/$CITY_MD5 $DEST/$CITY_MD5
     OUT=0
@@ -76,7 +78,9 @@ if [ ! -e $DEST/$COUNTRY_DB ] || [ ! -e $DEST/$COUNTRY_MD5 ] || [ "$(diff $TMP/$
 
   if [ "$(diff $TMP/COUNTRY_MD5 $TMP/$COUNTRY_MD5)" == "" ]; then
     tar -xf $TMP/$COUNTRY --no-same-owner --strip 1 -C $TMP
-    mv $DEST/$COUNTRY_DB $DEST/$COUNTRY_DB.old
+    if [ -e $DEST/$COUNTRY_DB ]; then
+        mv $DEST/$COUNTRY_DB $DEST/$COUNTRY_DB.old
+    fi
     mv $TMP/$COUNTRY_DB $DEST/$COUNTRY_DB
     mv $TMP/$COUNTRY_MD5 $DEST/$COUNTRY_MD5
     OUT=0


### PR DESCRIPTION
When first-time syncing to empty `/etc/GeoLite2`, no existing `.mmdb` files should be moved.